### PR TITLE
Fix small issues regarding escaping

### DIFF
--- a/admin/class-kelkoogroup-salestracking-admin.php
+++ b/admin/class-kelkoogroup-salestracking-admin.php
@@ -95,11 +95,11 @@ function kelkoogroup_salestracking_multicomid_render(  ) {
 }
 
 function kelkoogroup_salestracking_settings_intro_section_callback(  ) {
-    echo __( "<p>Kelkoogroup Sales Tracking requires a few configuration.</p>",'kelkoogroup-sales-tracking' );
+    echo esc_html__( "<p>Kelkoogroup Sales Tracking requires a few configuration.</p>",'kelkoogroup-sales-tracking' );
 }
 
 function kelkoogroup_salestracking_settings_onecampaign_section_callback(  ) {
-    echo __( "<p>          Merchant Identifier: This is the unique ID representing your shop within the Kelkoo system. You got it by email at your subscription, else to recover it you can ask your Kelkoogroup account manager. </p>
+    echo esc_html__( "<p>          Merchant Identifier: This is the unique ID representing your shop within the Kelkoo system. You got it by email at your subscription, else to recover it you can ask your Kelkoogroup account manager. </p>
  <p>          Country is the 2-letter country code for the country on which your products are listed on Kelkoo:
  'at' for Austria, 'be' for Belgium, 'br' for Brazil, 'ch' for Switzerland, 'cz' for Czech Republic, 'de' for Germany,
  'dk' for Denmark, 'es' for Spain, 'fi' for Finland, 'fr' for France, 'ie ' for Ireland, 'it' for Italy, 'mx' for Mexico,
@@ -110,7 +110,7 @@ function kelkoogroup_salestracking_settings_onecampaign_section_callback(  ) {
 }
 
 function kelkoogroup_salestracking_settings_multicomid_section_callback(  ) {
-    echo __( "<p>      Multi merchant information : If you need to configure multiple merchant information (you have multiple Merchant Identifier/Country), you can copy/paste the sample and update it.",
+    echo esc_html__( "<p>      Multi merchant information : If you need to configure multiple merchant information (you have multiple Merchant Identifier/Country), you can copy/paste the sample and update it.",
 'kelkoogroup-sales-tracking' );
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kelkoogroup
 Tags: kelkoogroup, sales, tracking, php, woocommerce
 Requires at least: 4.0.0
 Tested up to: 6.2
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -65,6 +65,9 @@ Once your subscription has been done, you will be able to access your Merchant E
 6. Go to the "Settings > Kelkoogroup" and set country and your company associated to your Kelkoogroup merchant account 
 
 == Changelog ==
+
+= 1.0.8 =
+* Fix small issues regarding escaping
 
 = 1.0.7 =
 * Improve plugin security and compatibility

--- a/woocommerce-kelkoogroup-salestracking.php
+++ b/woocommerce-kelkoogroup-salestracking.php
@@ -71,8 +71,8 @@ final class Kelkoogroup_SalesTracking {
               <?php } else { ?>
                merchantInfo: [<?php echo esc_js( $options['kelkoogroup_salestracking_multicomid'] );?>],
               <?php } ?>
-	       orderValue: '<?php echo esc_js( $order )->get_total();?>',
-               orderId: '<?php echo esc_js( $order )->get_order_number();?>',
+	       orderValue: '<?php echo esc_js( $order ->get_total());?>',
+               orderId: '<?php echo esc_js( $order ->get_order_number());?>',
                basket: <?php echo esc_js( json_encode($productsKelkoo) );?>
             };
              (function() {


### PR DESCRIPTION
Hi, thanks for the efforts, there are still some small issues regarding escaping

## Variables and options must be escaped when echo'd

Much related to sanitizing everything, all variables that are echoed need to be escaped when they're echoed, so it can't hijack users or (worse) admin screens. There are many esc_*() functions you can use to make sure you don't show people the wrong data, as well as some that will allow you to echo HTML safely.

At this time, we ask you escape all $-variables, options, and any sort of generated data when it is being echoed. That means you should not be escaping when you build a variable, but when you output it at the end. We call this 'escaping late.'

Besides protecting yourself from a possible XSS vulnerability, escaping late makes sure that you're keeping the future you safe. While today your code may be only outputted hardcoded content, that may not be true in the future. By taking the time to properly escape when you echo, you prevent a mistake in the future from becoming a critical security issue.

This remains true of options you've saved to the database. Even if you've properly sanitized when you saved, the tools for sanitizing and escaping aren't interchangeable. Sanitizing makes sure it's safe for processing and storing in the database. Escaping makes it safe to output.

Also keep in mind that sometimes a function is echoing when it should really be returning content instead. This is a common mistake when it comes to returning JSON encoded content. Very rarely is that actually something you should be echoing at all. Echoing is because it needs to be on the screen, read by a human. Returning (which is what you would do with an API) can be json encoded, though remember to sanitize when you save to that json object!

There are a number of options to secure all types of content (html, email, etc). Yes, even HTML needs to be properly escaped.

https://developer.wordpress.org/apis/security/escaping/

Remember: You must use the most appropriate functions for the context. There is pretty much an option for everything you could echo. Even echoing HTML safely.

Example(s) from your plugin:


kelkoogroup-sales-tracking/admin/class-kelkoogroup-salestracking-admin.php:98 echo __( "<p>Kelkoogroup Sales Tracking requires a few configuration.</p>",'kelkoogroup-sales-tracking' );
kelkoogroup-sales-tracking/admin/class-kelkoogroup-salestracking-admin.php:113 echo __( "<p>      Multi merchant information : If you need to configure multiple merchant information (you have multiple Merchant Identifier/Country), you can copy/paste the sample and update it.", 'kelkoogroup-sales-tracking' );
kelkoogroup-sales-tracking/admin/class-kelkoogroup-salestracking-admin.php:102 echo __( "<p>          Merchant Identifier: This is the unique ID representing your shop within the Kelkoo system. You got it by email at your subscription, else to recover it you can ask your Kelkoogroup account manager. </p> <p>          Country is the 2-letter country code for the country on which your products are listed on Kelkoo: 'at' for Austria, 'be' for Belgium, 'br' for Brazil, 'ch' for Switzerland, 'cz' for Czech Republic, 'de' for Germany, 'dk' for Denmark, 'es' for Spain, 'fi' for Finland, 'fr' for France, 'ie ' for Ireland, 'it' for Italy, 'mx' for Mexico, 'nb' for Flemish Belgium 'nl' for Netherlands, 'no' for Norway, 'pl' for Poland, 'pt' for Portugal, 'ru' for Russia, 'se' for Sweden, 'uk' for United Kingdom, 'us' for United States... </p> <p>You can get the full list on <a href='https://github.com/KelkooGroup/woocommerce-kelkoogroup-salestracking#country' target='_blank'>[https://github.com/KelkooGroup/woocommerce-kelkoogroup-salestracking#country</a](https://github.com/KelkooGroup/woocommerce-kelkoogroup-salestracking#country%3C/a)> </p>", 'kelkoogroup-sales-tracking' );
kelkoogroup-sales-tracking/woocommerce-kelkoogroup-salestracking.php:74 orderValue: '<?php echo esc_js( $order )->get_total();?>',
kelkoogroup-sales-tracking/woocommerce-kelkoogroup-salestracking.php:75 orderId: '<?php echo esc_js( $order )->get_order_number();?>',

As for the __() functions you can do it easily changing those to esc_html__() functions.

And in this situacion echo esc_js( $order )->get_total();
It's scaping the name of the variable, not the result of the call to that method, should be something like this echo esc_js( $order->get_total() );



--
WordPress Plugin Review Team | [plugins@wordpress.org](mailto:plugins@wordpress.org)
https://make.wordpress.org/plugins/
https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/