### PR TITLE
Fix saleId for multicampaign

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kelkoogroup
 Tags: kelkoogroup, sales, tracking, php, woocommerce
 Requires at least: 4.0.0
 Tested up to: 6.5.3
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -72,6 +72,8 @@ Once your subscription has been done, you will be able to access your Merchant E
 6. Go to the "Settings > Kelkoogroup" and set country and your company associated to your Kelkoogroup merchant account 
 
 == Changelog ==
+= 2.0.2 =
+* Fix saleId in the case of multi campaigns
 
 = 2.0.1 =
 * Remove retry mecanism

--- a/tests/Kelkoogroup_SalesTracking_Test.php
+++ b/tests/Kelkoogroup_SalesTracking_Test.php
@@ -100,7 +100,6 @@ class Kelkoogroup_SalesTracking_Test extends WP_UnitTestCase {
             ->getMock();
 
         $this->plugin_instance->method('kelkoogroup_salestracking_encode_basket')->willReturn('VGVzdCBkYXRhIGZvciBlbmNvZGluZw');
-        $this->plugin_instance->method('kelkoogroup_salestracking_generate_sale_id')->willReturn('0.55');
 
         // Set up transcient value for the test
         set_transient('kelkoogroup_salestracking_kk_identifier', 'transient_kelkoo_id');
@@ -110,7 +109,7 @@ class Kelkoogroup_SalesTracking_Test extends WP_UnitTestCase {
 
         $expected_url = 'https://s.kelkoogroup.net/st?country=fr&orderId=12345&comId=123&orderValue=100&productsInfos=VGVzdCBkYXRhIGZvciBlbmNvZGluZw&saleId=0.55&kelkooId=transient_kelkoo_id&gclid=cookie_gclid_id&source=serverToServer&ecommercePlatform=woocommerce';
 
-        $constructed_url = $this->plugin_instance->kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign);
+        $constructed_url = $this->plugin_instance->kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign, "0.55");
 
         // Assert that the constructed URL matches the expected URL
         $this->assertEquals($expected_url, $constructed_url);

--- a/woocommerce-kelkoogroup-salestracking.php
+++ b/woocommerce-kelkoogroup-salestracking.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Kelkoogroup Sales Tracking
  * Description:       Plugin to contain Kelkoogroup sales tracking customisation for Woocommerce
  * Plugin URI:        https://github.com/KelkooGroup/woocommerce-kelkoogroup-salestracking
- * Version:           2.0.1
+ * Version:           2.0.2
 
  * Author:            Kelkoo Group
  * Author URI:        https://www.kelkoogroup.com/
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main Kelkoogroup_SalesTracking Class
  *
  * @class Kelkoogroup_SalesTracking
- * @version	2.0.1
+ * @version	2.0.2
  * @since 1.0.0
  * @package	Kelkoogroup_SalesTracking
  */
@@ -118,10 +118,11 @@ class Kelkoogroup_SalesTracking {
                 'merchantId' => $options['kelkoogroup_salestracking_comid']
             );
         }
+        $saleId = $this->kelkoogroup_salestracking_generate_sale_id();
     
         // Send server call for each campaign
         foreach ($campaigns as $campaign) {
-            $request_url = $this->kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign);
+            $request_url = $this->kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign, $saleId);
             $response = wp_remote_get($request_url, array(
                 'headers' => $headers,
                 'blocking' => false,
@@ -162,7 +163,7 @@ class Kelkoogroup_SalesTracking {
      /**
      * Construct the URL for the Kelkoogroup request
      */
-    function kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign) {
+    function kelkoogroup_salestracking_construct_kelkoogroup_request_url($order, $productsKelkoo, $campaign, $saleId) {
       $kelkoo_id = get_transient('kelkoogroup_salestracking_kk_identifier');
       $gclid_id = get_transient('kelkoogroup_salestracking_gclid_identifier');
       $msclkid_id = get_transient('kelkoogroup_salestracking_msclkid_identifier');
@@ -186,7 +187,7 @@ class Kelkoogroup_SalesTracking {
           'comId' => $campaign['merchantId'],
           'orderValue' => $order->get_total(),
           'productsInfos' => $this->kelkoogroup_salestracking_encode_basket($productsKelkoo),
-          'saleId' => $this->kelkoogroup_salestracking_generate_sale_id(),
+          'saleId' => $saleId,
           'kelkooId' => $kelkoo_id ?: null,
           'gclid' => $gclid_id ?: null,
           'msclkid' => $msclkid_id ?: null,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [KelkooGroup Sales tracking Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #TT-1475 .

### How to test the changes in this Pull Request:

1. Made a sale for multi campaign, and check that the saleId value on the kelkoogroup server log

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


